### PR TITLE
replace golang.org/x/exp/slices with slices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/antlr4-go/antlr/v4
 
 go 1.22
-
-require golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=

--- a/lexer_action_executor.go
+++ b/lexer_action_executor.go
@@ -4,7 +4,7 @@
 
 package antlr
 
-import "golang.org/x/exp/slices"
+import "slices"
 
 // Represents an executor for a sequence of lexer actions which traversed during
 // the Matching operation of a lexer rule (token).


### PR DESCRIPTION
Replace `golang.org/x/exp/slices` with `slices`.
The `slices` package is officially available in go 1.21, so the golang.org/x/exp dependency can be removed.