### PR TITLE
fix: BailErrorStrategy.Recover panics instead of SetError

### DIFF
--- a/error_strategy.go
+++ b/error_strategy.go
@@ -672,10 +672,13 @@ func NewBailErrorStrategy() *BailErrorStrategy {
 	return b
 }
 
-// Recover Instead of recovering from exception e, re-panic it wrapped
-// in a [ParseCancellationException] so it is not caught by the
-// rule func catches. Use Exception.GetCause() to get the
-// original [RecognitionException].
+// Recover stamps the original exception on every ancestor context, then panics
+// with a [ParseCancellationException] so the error escapes the generated rule
+// functions and can be caught by the caller's recover().
+//
+// This matches the Java runtime, where Recover throws ParseCancellationException
+// (which is not a RecognitionException) so it bypasses the parser's internal
+// catch blocks entirely.
 func (b *BailErrorStrategy) Recover(recognizer Parser, e RecognitionException) {
 	context := recognizer.GetParserRuleContext()
 	for context != nil {
@@ -686,15 +689,14 @@ func (b *BailErrorStrategy) Recover(recognizer Parser, e RecognitionException) {
 			context = nil
 		}
 	}
-	recognizer.SetError(NewParseCancellationException()) // TODO: we don't emit e properly
+	panic(NewParseCancellationException(e))
 }
 
-// RecoverInline makes sure we don't attempt to recover inline if the parser
-// successfully recovers, it won't panic an exception.
+// RecoverInline creates an [InputMisMatchException] and delegates to [Recover],
+// which panics with a [ParseCancellationException].
 func (b *BailErrorStrategy) RecoverInline(recognizer Parser) Token {
 	b.Recover(recognizer, NewInputMisMatchException(recognizer))
-
-	return nil
+	return nil // unreachable — Recover always panics
 }
 
 // Sync makes sure we don't attempt to recover from problems in sub-rules.

--- a/errors.go
+++ b/errors.go
@@ -234,26 +234,37 @@ func (f *FailedPredicateException) formatMessage(predicate, message string) stri
 	return "failed predicate: {" + predicate + "}?"
 }
 
+// ParseCancellationException is panicked (not returned) by [BailErrorStrategy]
+// to immediately abort the parse. It wraps the original [RecognitionException]
+// that triggered the cancellation.
+//
+// In the Java runtime this class extends CancellationException, NOT
+// RecognitionException, so it escapes the parser's internal catch blocks.
+// The Go equivalent is a panic value that does not satisfy the
+// [RecognitionException] interface.
+//
+// Callers performing two-stage (SLL then LL) parsing should recover() the
+// panic and inspect [GetCause] for the underlying error.
 type ParseCancellationException struct {
+	cause RecognitionException
 }
 
-func (p ParseCancellationException) GetOffendingToken() Token {
-	//TODO implement me
-	panic("implement me")
+// GetCause returns the original [RecognitionException] that triggered the
+// cancellation, or nil if none was provided.
+func (p *ParseCancellationException) GetCause() RecognitionException {
+	return p.cause
 }
 
-func (p ParseCancellationException) GetMessage() string {
-	//TODO implement me
-	panic("implement me")
+// Error implements the error interface.
+func (p *ParseCancellationException) Error() string {
+	if p.cause != nil {
+		return "parse cancelled: " + p.cause.GetMessage()
+	}
+	return "parse cancelled"
 }
 
-func (p ParseCancellationException) GetInputStream() IntStream {
-	//TODO implement me
-	panic("implement me")
-}
-
-func NewParseCancellationException() *ParseCancellationException {
-	//	Error.call(this)
-	//	Error.captureStackTrace(this, ParseCancellationException)
-	return new(ParseCancellationException)
+// NewParseCancellationException creates a [ParseCancellationException] wrapping
+// the given cause. Pass nil if no cause is available.
+func NewParseCancellationException(cause RecognitionException) *ParseCancellationException {
+	return &ParseCancellationException{cause: cause}
 }


### PR DESCRIPTION
The Go runtime's BailErrorStrategy.Recover called recognizer.SetError() with a ParseCancellationException, but did not panic. This allowed execution to continue into DefaultErrorStrategy.ReportError, which then encountered the ParseCancellationException — a type not in its switch — and printed "unknown recognition error type:" to stdout. It then called GetMessage()/GetOffendingToken() on ParseCancellationException, which were unimplemented stubs that panicked with "implement me".

The Java runtime's BailErrorStrategy.recover() throws ParseCancellationException (which extends CancellationException, not RecognitionException), so it escapes the parser entirely.

This commit aligns the Go runtime with Java:

- BailErrorStrategy.Recover now panics with a *ParseCancellationException (wrapping the original RecognitionException as a cause) so the error escapes the generated rule functions immediately.

- ParseCancellationException no longer implements RecognitionException. The stub methods (GetOffendingToken, GetMessage, GetInputStream) that panicked with "implement me" are removed. Instead it carries a cause field accessible via GetCause() and implements the error interface.

- NewParseCancellationException now takes a cause argument, matching the Java constructor.

Callers using BailErrorStrategy should defer/recover and type-assert the panic value to *ParseCancellationException. This was already the documented usage pattern.