### PR TITLE
fix: remove stray fmt.Println from DefaultErrorStrategy.ReportError

### DIFF
--- a/error_strategy.go
+++ b/error_strategy.go
@@ -5,8 +5,6 @@
 package antlr
 
 import (
-	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 )
@@ -103,8 +101,6 @@ func (d *DefaultErrorStrategy) ReportError(recognizer Parser, e RecognitionExcep
 
 	switch t := e.(type) {
 	default:
-		fmt.Println("unknown recognition error type: " + reflect.TypeOf(e).Name())
-		//            fmt.Println(e.stack)
 		recognizer.NotifyErrorListeners(e.GetMessage(), e.GetOffendingToken(), e)
 	case *NoViableAltException:
 		d.ReportNoViableAlternative(recognizer, t)


### PR DESCRIPTION
The default case in ReportError printed "unknown recognition error type:" to stdout via fmt.Println before forwarding the error to NotifyErrorListeners. This debug output was not present in the Java runtime and leaked uncontrolled output to stdout during normal parsing, making it impossible for callers to cleanly capture parser errors through the error listener API.

The Java runtime's DefaultErrorStrategy.reportError simply calls notifyErrorListeners for unrecognised exception types without any console output.

This commit removes the fmt.Println (and the commented-out stack trace line below it), along with the now-unused fmt and reflect imports. The error is still reported through recognizer.NotifyErrorListeners as before.